### PR TITLE
Upgrade angular2-in-memory-web-api to ^0.0.20

### DIFF
--- a/00-Starter-Seed/package.json
+++ b/00-Starter-Seed/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23 ",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/02-Custom-Login/package.json
+++ b/02-Custom-Login/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/03-Session-Handling/package.json
+++ b/03-Session-Handling/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/04-User-Profile/package.json
+++ b/04-User-Profile/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/05-Linking-Accounts/package.json
+++ b/05-Linking-Accounts/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/06-Rules/package.json
+++ b/06-Rules/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/07-Authorization/package.json
+++ b/07-Authorization/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/08-Calling-Api/package.json
+++ b/08-Calling-Api/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/09-MFA/package.json
+++ b/09-MFA/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",

--- a/10-Customizing-Lock/package.json
+++ b/10-Customizing-Lock/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.14",
+    "angular2-in-memory-web-api": "^0.0.20",
     "angular2-jwt": "^0.1.23",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",


### PR DESCRIPTION
This should get rid of warnings we've been getting with unmet peer dependencies