### PR TITLE
remove base64 encode

### DIFF
--- a/Server/server.js
+++ b/Server/server.js
@@ -5,7 +5,7 @@ var app = express();
 var jwt = require('express-jwt');
 
 var authenticate = jwt({
-  secret: new Buffer('YOUR_SECRET', 'base64'),
+  secret: new Buffer('YOUR_SECRET'),
   audience: 'YOUR_CLIENT_ID'
 });
 


### PR DESCRIPTION
It wasn't necessary base or atleast, optional, because Client Secret is not longer encoded, right?