### PR TITLE
tokenNotExpired requires a key

### DIFF
--- a/01-Login/app/auth.service.ts
+++ b/01-Login/app/auth.service.ts
@@ -25,7 +25,7 @@ export class Auth {
   public authenticated() {
     // Check if there's an unexpired JWT
     // It searches for an item in localStorage with key == 'id_token'
-    return tokenNotExpired();
+    return tokenNotExpired('id_token');
   };
 
   public logout() {


### PR DESCRIPTION
Not providing the key results in the method returning false.